### PR TITLE
Feat: 점 대신 선을 동영상에 그림

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.kotlinisgood.boomerang">
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-feature android:glEsVersion="0x00020000" android:required="true" />
 
     <application
         android:name=".MemoApplication"

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
@@ -136,7 +136,8 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
                     drawLine(motionEvent.x.toInt(), motionEvent.y.toInt())
                 }
                 MotionEvent.ACTION_MOVE -> {
-                    drawLine(motionEvent.x.toInt(), motionEvent.y.toInt())
+//                    drawLine(motionEvent.x.toInt(), motionEvent.y.toInt())
+                    fillSpace(motionEvent.x.toInt(), motionEvent.y.toInt())
                 }
                 MotionEvent.ACTION_UP -> {
                 }
@@ -148,6 +149,13 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
 
     private fun drawLine(x: Int, y: Int) {
         currentPoint.add(Pair(x, y))
+    }
+
+    private fun fillSpace(x: Int, y: Int) {
+        val last = currentPoint.last()
+        for (i in 1..100) {
+            currentPoint.add(Pair(last.first + (x - last.first)*i/100, last.second + (y - last.second)*i/100))
+        }
     }
 
     override fun surfaceCreated(p0: SurfaceHolder) {
@@ -247,11 +255,11 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
         currentPoint.forEach {
             GLES20.glClearColor(1f, 1f, 0f, 1f)
             GLES20.glEnable(GLES20.GL_SCISSOR_TEST)
-            GLES20.glScissor(it.first, height - it.second, 20, 20)
+            GLES20.glScissor(it.first, height - it.second, 15, 15)
             GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT)
             GLES20.glDisable(GLES20.GL_SCISSOR_TEST)
         }
-
+        println(currentPoint)
 //        점 이어서 선 그리기
 //        GLES20.glClearColor(1f, 1f, 0f, 1f)
 //        val vertices = ByteBuffer.allocateDirect(touchPoints.size * 4).run {


### PR DESCRIPTION
## Related Issue
* Close: #31 

## Overview
기존에 onTouchListener에서 위치를 그대로 점으로 찍던 것을 개선하여 이전 위치와 현재 위치 사이에 점을 추가로 100개 그려넣음

## Screen Shot
| Before | After |
| :---: | :---: |
|![image](https://user-images.githubusercontent.com/37128456/140714654-c642a2d2-23a0-4a5b-a945-104a821e1596.png)| ![image](https://user-images.githubusercontent.com/37128456/140714409-e055734d-e11c-4b17-b4b5-911e90b62fe0.png)|
