### PR TITLE
[Frame 메모 작성 화면] Capture 버튼 클릭시 발생하는 에러 수정

### DIFF
--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/AspectFrameLayout.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/AspectFrameLayout.kt
@@ -87,6 +87,6 @@ class AspectFrameLayout : FrameLayout {
     }
 
     companion object {
-        private val TAG: String = "AspectFrameLayoutTAG"
+        private const val TAG: String = "AspectFrameLayoutTAG"
     }
 }

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/CircularEncoder.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/CircularEncoder.kt
@@ -425,7 +425,7 @@ class CircularEncoder(
     }
 
     companion object {
-        private val TAG: String = "CircularEncoderTAG"
+        private const val TAG: String = "CircularEncoderTAG"
         private val VERBOSE = false
         private val MIME_TYPE = "video/avc" // H.264 Advanced Video Coding
         private val IFRAME_INTERVAL = 1 // sync frame every second

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/CircularEncoderBuffer.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/CircularEncoderBuffer.kt
@@ -263,7 +263,7 @@ class CircularEncoderBuffer(bitRate: Int, frameRate: Int, desiredSpanSec: Int) {
     }
 
     companion object {
-        private val TAG: String = "CircularEncoderBufTAG"
+        private const val TAG: String = "CircularEncoderBufTAG"
         private val EXTRA_DEBUG = true
         private val VERBOSE = false
     }

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/EglCore.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/EglCore.kt
@@ -249,7 +249,7 @@ class EglCore @JvmOverloads constructor(sharedContext: EGLContext? = null, flags
     }
 
     companion object {
-        private val TAG: String = "EglCoreTAG"
+        private const val TAG: String = "EglCoreTAG"
 
         /**
          * Constructor flag: surface must be recordable.  This discourages EGL from using a

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/EglSurfaceBase.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/EglSurfaceBase.kt
@@ -173,6 +173,6 @@ open class EglSurfaceBase protected constructor(  // EglCore object we're associ
     }
 
     companion object {
-        protected val TAG: String = GlUtil.TAG
+        private const val TAG: String = "EglSurfaceBaseTAG"
     }
 }

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/GlUtil.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/GlUtil.kt
@@ -14,7 +14,7 @@ import java.nio.FloatBuffer
  * Some OpenGL utility functions.
  */
 object GlUtil {
-    const val TAG = "Grafika"
+    private const val TAG = "GlUtilTAG"
 
     /** Identity matrix for general use.  Don't modify or life will get weird.  */
     val IDENTITY_MATRIX: FloatArray

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/Texture2dProgram.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/Texture2dProgram.kt
@@ -193,7 +193,7 @@ class Texture2dProgram(
     }
 
     companion object {
-        private val TAG = GlUtil.TAG
+        private const val TAG = "Texture2dProgramTAG"
 
         // Simple vertex shader, used for all programs.
         private val VERTEX_SHADER = ("uniform mat4 uMVPMatrix;\n" +


### PR DESCRIPTION
## Related Issue
* Close: #34 

## Overview
### 안드로이드 생명주기에 따른 처리
- MediaPlayer에서 동영상 정지 후 해제
- SurfaceTexture 해제
- 각 Surface들 해제

### 다음 화면으로 넘기는 시점 조절
- 동영상이 저장된 것을 확인한 후 다음 화면으로 이동하도록 함

추가로 TAG 형식을 안드로이드의 코딩 컨벤션에 맞게 수정
```kotlin
companion object {
    private const val TAG = "WriteSomethingTAG"
}
```

