### PR TITLE
[모두의 메모 작성 화면] 렌더링 과정 개선

### DIFF
--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/EglCore.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/EglCore.kt
@@ -4,64 +4,32 @@ import android.graphics.SurfaceTexture
 import android.opengl.*
 import android.util.Log
 import android.view.Surface
-import java.lang.RuntimeException
 
-/**
- * Core EGL state (display, context, config).
- *
- *
- * The EGLContext must only be attached to one thread at a time.  This class is not thread-safe.
- */
-class EglCore @JvmOverloads constructor(sharedContext: EGLContext? = null, flags: Int = 0) {
-    private var mEGLDisplay = EGL14.EGL_NO_DISPLAY
-    private var mEGLContext = EGL14.EGL_NO_CONTEXT
-    private var mEGLConfig: EGLConfig? = null
+class EglCore {
+    private lateinit var eglDisplay: EGLDisplay
+
+    //    private var eglContext = EGL14.EGL_NO_CONTEXT
+    private lateinit var eglContext: EGLContext
+    private var eglConfig: EGLConfig? = null
 
     /**
      * Returns the GLES version this context is configured for (currently 2 or 3).
      */
     var glVersion = -1
 
-    /**
-     * Finds a suitable EGLConfig.
-     *
-     * @param flags Bit flags from constructor.
-     * @param version Must be 2 or 3.
-     */
-    private fun getConfig(flags: Int, version: Int): EGLConfig? {
-        var renderableType = EGL14.EGL_OPENGL_ES2_BIT
-        if (version >= 3) {
-            renderableType = renderableType or EGLExt.EGL_OPENGL_ES3_BIT_KHR
-        }
+    init {
+        getEglDisplay()
+        eglInit()
+        eglBind()
+        getEglContext()
 
-        // The actual surface is generally RGBA or RGBX, so situationally omitting alpha
-        // doesn't really help.  It can also lead to a huge performance hit on glReadPixels()
-        // when reading into a GL_RGBA buffer.
-        val attribList = intArrayOf(
-            EGL14.EGL_RED_SIZE, 8,
-            EGL14.EGL_GREEN_SIZE, 8,
-            EGL14.EGL_BLUE_SIZE, 8,
-            EGL14.EGL_ALPHA_SIZE, 8,  //EGL14.EGL_DEPTH_SIZE, 16,
-            //EGL14.EGL_STENCIL_SIZE, 8,
-            EGL14.EGL_RENDERABLE_TYPE, renderableType,
-            EGL14.EGL_NONE, 0,  // placeholder for recordable [@-3]
-            EGL14.EGL_NONE
+        // Confirm with query.
+        val values = IntArray(1)
+        EGL14.eglQueryContext(
+            eglDisplay, eglContext, EGL14.EGL_CONTEXT_CLIENT_VERSION,
+            values, 0
         )
-        if (flags and FLAG_RECORDABLE != 0) {
-            attribList[attribList.size - 3] = EGL_RECORDABLE_ANDROID
-            attribList[attribList.size - 2] = 1
-        }
-        val configs = arrayOfNulls<EGLConfig>(1)
-        val numConfigs = IntArray(1)
-        if (!EGL14.eglChooseConfig(
-                mEGLDisplay, attribList, 0, configs, 0, configs.size,
-                numConfigs, 0
-            )
-        ) {
-            Log.w(TAG, "unable to find RGB8888 / $version EGLConfig")
-            return null
-        }
-        return configs[0]
+        Log.d(TAG, "EGLContext created, client version " + values[0])
     }
 
     /**
@@ -72,26 +40,26 @@ class EglCore @JvmOverloads constructor(sharedContext: EGLContext? = null, flags
      * On completion, no context will be current.
      */
     fun release() {
-        if (mEGLDisplay !== EGL14.EGL_NO_DISPLAY) {
+        if (eglDisplay !== EGL14.EGL_NO_DISPLAY) {
             // Android is unusual in that it uses a reference-counted EGLDisplay.  So for
             // every eglInitialize() we need an eglTerminate().
             EGL14.eglMakeCurrent(
-                mEGLDisplay, EGL14.EGL_NO_SURFACE, EGL14.EGL_NO_SURFACE,
+                eglDisplay, EGL14.EGL_NO_SURFACE, EGL14.EGL_NO_SURFACE,
                 EGL14.EGL_NO_CONTEXT
             )
-            EGL14.eglDestroyContext(mEGLDisplay, mEGLContext)
+            EGL14.eglDestroyContext(eglDisplay, eglContext)
             EGL14.eglReleaseThread()
-            EGL14.eglTerminate(mEGLDisplay)
+            EGL14.eglTerminate(eglDisplay)
         }
-        mEGLDisplay = EGL14.EGL_NO_DISPLAY
-        mEGLContext = EGL14.EGL_NO_CONTEXT
-        mEGLConfig = null
+        eglDisplay = EGL14.EGL_NO_DISPLAY
+        eglContext = EGL14.EGL_NO_CONTEXT
+//        eglConfig = null
     }
 
     @Throws(Throwable::class)
     protected fun finalize() {
         try {
-            if (mEGLDisplay !== EGL14.EGL_NO_DISPLAY) {
+            if (eglDisplay !== EGL14.EGL_NO_DISPLAY) {
                 // We're limited here -- finalizers don't run on the thread that holds
                 // the EGL state, so if a surface or context is still current on another
                 // thread we can't fully release it here.  Exceptions thrown from here
@@ -109,7 +77,7 @@ class EglCore @JvmOverloads constructor(sharedContext: EGLContext? = null, flags
      * still current in a context.
      */
     fun releaseSurface(eglSurface: EGLSurface?) {
-        EGL14.eglDestroySurface(mEGLDisplay, eglSurface)
+        EGL14.eglDestroySurface(eglDisplay, eglSurface)
     }
 
     /**
@@ -120,7 +88,7 @@ class EglCore @JvmOverloads constructor(sharedContext: EGLContext? = null, flags
      */
     fun createWindowSurface(surface: Any): EGLSurface {
         if (surface !is Surface && surface !is SurfaceTexture) {
-            throw RuntimeException("invalid surface: $surface")
+            throw Exception("invalid surface: $surface")
         }
 
         // Create a window surface, and attach it to the Surface we received.
@@ -128,12 +96,12 @@ class EglCore @JvmOverloads constructor(sharedContext: EGLContext? = null, flags
             EGL14.EGL_NONE
         )
         val eglSurface = EGL14.eglCreateWindowSurface(
-            mEGLDisplay, mEGLConfig, surface,
+            eglDisplay, eglConfig, surface,
             surfaceAttribs, 0
         )
         checkEglError("eglCreateWindowSurface")
         if (eglSurface == null) {
-            throw RuntimeException("surface was null")
+            throw Exception("surface was null")
         }
         return eglSurface
     }
@@ -148,12 +116,12 @@ class EglCore @JvmOverloads constructor(sharedContext: EGLContext? = null, flags
             EGL14.EGL_NONE
         )
         val eglSurface = EGL14.eglCreatePbufferSurface(
-            mEGLDisplay, mEGLConfig,
+            eglDisplay, eglConfig,
             surfaceAttribs, 0
         )
         checkEglError("eglCreatePbufferSurface")
         if (eglSurface == null) {
-            throw RuntimeException("surface was null")
+            throw Exception("surface was null")
         }
         return eglSurface
     }
@@ -162,12 +130,12 @@ class EglCore @JvmOverloads constructor(sharedContext: EGLContext? = null, flags
      * Makes our EGL context current, using the supplied surface for both "draw" and "read".
      */
     fun makeCurrent(eglSurface: EGLSurface?) {
-        if (mEGLDisplay === EGL14.EGL_NO_DISPLAY) {
+        if (eglDisplay === EGL14.EGL_NO_DISPLAY) {
             // called makeCurrent() before create?
             Log.d(TAG, "NOTE: makeCurrent w/o display")
         }
-        if (!EGL14.eglMakeCurrent(mEGLDisplay, eglSurface, eglSurface, mEGLContext)) {
-            throw RuntimeException("eglMakeCurrent failed")
+        if (!EGL14.eglMakeCurrent(eglDisplay, eglSurface, eglSurface, eglContext)) {
+            throw Exception("eglMakeCurrent failed")
         }
     }
 
@@ -175,12 +143,12 @@ class EglCore @JvmOverloads constructor(sharedContext: EGLContext? = null, flags
      * Makes our EGL context current, using the supplied "draw" and "read" surfaces.
      */
     fun makeCurrent(drawSurface: EGLSurface?, readSurface: EGLSurface?) {
-        if (mEGLDisplay === EGL14.EGL_NO_DISPLAY) {
+        if (eglDisplay === EGL14.EGL_NO_DISPLAY) {
             // called makeCurrent() before create?
             Log.d(TAG, "NOTE: makeCurrent w/o display")
         }
-        if (!EGL14.eglMakeCurrent(mEGLDisplay, drawSurface, readSurface, mEGLContext)) {
-            throw RuntimeException("eglMakeCurrent(draw,read) failed")
+        if (!EGL14.eglMakeCurrent(eglDisplay, drawSurface, readSurface, eglContext)) {
+            throw Exception("eglMakeCurrent(draw,read) failed")
         }
     }
 
@@ -189,11 +157,11 @@ class EglCore @JvmOverloads constructor(sharedContext: EGLContext? = null, flags
      */
     fun makeNothingCurrent() {
         if (!EGL14.eglMakeCurrent(
-                mEGLDisplay, EGL14.EGL_NO_SURFACE, EGL14.EGL_NO_SURFACE,
+                eglDisplay, EGL14.EGL_NO_SURFACE, EGL14.EGL_NO_SURFACE,
                 EGL14.EGL_NO_CONTEXT
             )
         ) {
-            throw RuntimeException("eglMakeCurrent failed")
+            throw Exception("eglMakeCurrent failed")
         }
     }
 
@@ -203,21 +171,21 @@ class EglCore @JvmOverloads constructor(sharedContext: EGLContext? = null, flags
      * @return false on failure
      */
     fun swapBuffers(eglSurface: EGLSurface?): Boolean {
-        return EGL14.eglSwapBuffers(mEGLDisplay, eglSurface)
+        return EGL14.eglSwapBuffers(eglDisplay, eglSurface)
     }
 
     /**
      * Sends the presentation time stamp to EGL.  Time is expressed in nanoseconds.
      */
     fun setPresentationTime(eglSurface: EGLSurface?, nsecs: Long) {
-        EGLExt.eglPresentationTimeANDROID(mEGLDisplay, eglSurface, nsecs)
+        EGLExt.eglPresentationTimeANDROID(eglDisplay, eglSurface, nsecs)
     }
 
     /**
      * Returns true if our context and the specified surface are current.
      */
     fun isCurrent(eglSurface: EGLSurface): Boolean {
-        return mEGLContext == EGL14.eglGetCurrentContext() && eglSurface == EGL14.eglGetCurrentSurface(
+        return eglContext == EGL14.eglGetCurrentContext() && eglSurface == EGL14.eglGetCurrentSurface(
             EGL14.EGL_DRAW
         )
     }
@@ -227,7 +195,7 @@ class EglCore @JvmOverloads constructor(sharedContext: EGLContext? = null, flags
      */
     fun querySurface(eglSurface: EGLSurface?, what: Int): Int {
         val value = IntArray(1)
-        EGL14.eglQuerySurface(mEGLDisplay, eglSurface, what, value, 0)
+        EGL14.eglQuerySurface(eglDisplay, eglSurface, what, value, 0)
         return value[0]
     }
 
@@ -235,7 +203,7 @@ class EglCore @JvmOverloads constructor(sharedContext: EGLContext? = null, flags
      * Queries a string value.
      */
     fun queryString(what: Int): String {
-        return EGL14.eglQueryString(mEGLDisplay, what)
+        return EGL14.eglQueryString(eglDisplay, what)
     }
 
     /**
@@ -244,7 +212,7 @@ class EglCore @JvmOverloads constructor(sharedContext: EGLContext? = null, flags
     private fun checkEglError(msg: String) {
         var error: Int
         if (EGL14.eglGetError().also { error = it } != EGL14.EGL_SUCCESS) {
-            throw RuntimeException(msg + ": EGL error: 0x" + Integer.toHexString(error))
+            throw Exception(msg + ": EGL error: 0x" + Integer.toHexString(error))
         }
     }
 
@@ -283,82 +251,117 @@ class EglCore @JvmOverloads constructor(sharedContext: EGLContext? = null, flags
             )
         }
     }
+
     /**
-     * Prepares EGL display and context.
-     *
-     *
-     * @param sharedContext The context to share, or null if sharing is not desired.
-     * @param flags Configuration bit flags, e.g. FLAG_RECORDABLE.
+     * EGLDisplay 가져오기
+     * 렌더링 할 수 있는 하드웨어 리소스를 주어서 EGL이 하드웨어의 API를 사용할 수 있도록 하자
+     * EGL_DEFAULT_DISPLAY: OS가 기본으로 제공하는 디스플레이
      */
+    private fun getEglDisplay() {
+        eglDisplay = EGL14.eglGetDisplay(EGL14.EGL_DEFAULT_DISPLAY)
+        if (eglDisplay === EGL14.EGL_NO_DISPLAY) throw Exception("EGLDisplay 가져오기 실패")
+    }
+
     /**
-     * Prepares EGL display and context.
-     *
-     *
-     * Equivalent to EglCore(null, 0).
+     * EGL 초기화
+     * eglInitialize(EGLDisplay, EGL 메이저 버전, EGL 마이너 버전)
+     * T/F로 초기화 성공 여부 반환
      */
-    init {
-        var sharedContext = sharedContext
-        if (mEGLDisplay !== EGL14.EGL_NO_DISPLAY) {
-            throw RuntimeException("EGL already set up")
-        }
-        if (sharedContext == null) {
-            sharedContext = EGL14.EGL_NO_CONTEXT
-        }
-        mEGLDisplay = EGL14.eglGetDisplay(EGL14.EGL_DEFAULT_DISPLAY)
-        if (mEGLDisplay === EGL14.EGL_NO_DISPLAY) {
-            throw RuntimeException("unable to get EGL14 display")
-        }
+    private fun eglInit() {
         val version = IntArray(2)
-        if (!EGL14.eglInitialize(mEGLDisplay, version, 0, version, 1)) {
-            mEGLDisplay = null
-            throw RuntimeException("unable to initialize EGL14")
+        if (!EGL14.eglInitialize(eglDisplay, version, 0, version, 0)) throw Exception("EGL 초기화 실패")
+    }
+
+    /**
+     * EGL 렌더링 API 설정 (OPENGL, OPENGL_ES, OPENVG 등이 있음)
+     * T/F로 설정 성공 여부 반환
+     */
+    private fun eglBind() {
+        if (!EGL14.eglBindAPI(EGL14.EGL_OPENGL_ES_API)) throw Exception("EGL 렌더링 API 설정 실패")
+    }
+
+    /**
+     * Finds a suitable EGLConfig.
+     *
+     * @param version Must be 2 or 3.
+     */
+    private fun getEglConfig(version: Int) {
+        var renderableType = EGL14.EGL_OPENGL_ES2_BIT
+        if (version >= 3) {
+            renderableType = renderableType or EGLExt.EGL_OPENGL_ES3_BIT_KHR
         }
 
-        // Try to get a GLES3 context, if requested.
-        if (flags and FLAG_TRY_GLES3 != 0) {
-            //Log.d(TAG, "Trying GLES 3");
-            val config = getConfig(flags, 3)
-            if (config != null) {
-                val attrib3_list = intArrayOf(
-                    EGL14.EGL_CONTEXT_CLIENT_VERSION, 3,
-                    EGL14.EGL_NONE
-                )
-                val context = EGL14.eglCreateContext(
-                    mEGLDisplay, config, sharedContext,
-                    attrib3_list, 0
-                )
-                if (EGL14.eglGetError() == EGL14.EGL_SUCCESS) {
-                    //Log.d(TAG, "Got GLES 3 config");
-                    mEGLConfig = config
-                    mEGLContext = context
-                    glVersion = 3
-                }
-            }
+        // The actual surface is generally RGBA or RGBX, so situationally omitting alpha
+        // doesn't really help.  It can also lead to a huge performance hit on glReadPixels()
+        // when reading into a GL_RGBA buffer.
+        val attribList = intArrayOf(
+            EGL14.EGL_RED_SIZE, 8,
+            EGL14.EGL_GREEN_SIZE, 8,
+            EGL14.EGL_BLUE_SIZE, 8,
+            EGL14.EGL_ALPHA_SIZE, 8,  //EGL14.EGL_DEPTH_SIZE, 16,
+            //EGL14.EGL_STENCIL_SIZE, 8,
+            EGL14.EGL_RENDERABLE_TYPE, renderableType,
+            EGL14.EGL_NONE, 0,  // placeholder for recordable [@-3]
+            EGL14.EGL_NONE
+        )
+        attribList[attribList.size - 3] = EGL_RECORDABLE_ANDROID
+        attribList[attribList.size - 2] = 1
+        val configs = arrayOfNulls<EGLConfig>(1)
+        val numConfigs = IntArray(1)
+        if (!EGL14.eglChooseConfig(
+                eglDisplay,
+                attribList,
+                0,
+                configs,
+                0,
+                configs.size,
+                numConfigs,
+                0
+            )
+        ) {
+            Log.d(TAG, "$version EGLConfig 실패")
+            eglConfig = null
         }
-        if (mEGLContext === EGL14.EGL_NO_CONTEXT) {  // GLES 2 only, or GLES 3 attempt failed
-            //Log.d(TAG, "Trying GLES 2");
-            val config = getConfig(flags, 2)
-                ?: throw RuntimeException("Unable to find a suitable EGLConfig")
+        eglConfig = configs[0]
+//        return configs[0]
+//        if (eglConfig == null) getEglConfig(2)
+    }
+
+    /**
+     * OS의 WindowManager가 할 수 있는 API 목록을 EGLConfig를 통해 전달
+     * 우선 OpenGL ES version 3을 시도하고, 실패시 2를 시도. 이마저 실패하면 Exception
+     */
+    private fun getEglContext() {
+        getEglConfig(3)
+        if (eglConfig != null) {
+            val attrib3_list = intArrayOf(
+                EGL14.EGL_CONTEXT_CLIENT_VERSION, 3,
+                EGL14.EGL_NONE
+            )
+            val context = EGL14.eglCreateContext(
+                eglDisplay, eglConfig, EGL14.EGL_NO_CONTEXT,
+                attrib3_list, 0
+            )
+            if (EGL14.eglGetError() == EGL14.EGL_SUCCESS) {
+                Log.d(TAG, "Got GLES 3 config");
+                eglContext = context
+                glVersion = 3
+            }
+        } else {
+            getEglConfig(2)
+            if(eglConfig == null) throw Exception("Unable to find a suitable EGLConfig")
             val attrib2_list = intArrayOf(
                 EGL14.EGL_CONTEXT_CLIENT_VERSION, 2,
                 EGL14.EGL_NONE
             )
             val context = EGL14.eglCreateContext(
-                mEGLDisplay, config, sharedContext,
+                eglDisplay, eglConfig, EGL14.EGL_NO_CONTEXT,
                 attrib2_list, 0
             )
             checkEglError("eglCreateContext")
-            mEGLConfig = config
-            mEGLContext = context
+            Log.d(TAG, "Got GLES 2 config");
+            eglContext = context
             glVersion = 2
         }
-
-        // Confirm with query.
-        val values = IntArray(1)
-        EGL14.eglQueryContext(
-            mEGLDisplay, mEGLContext, EGL14.EGL_CONTEXT_CLIENT_VERSION,
-            values, 0
-        )
-        Log.d(TAG, "EGLContext created, client version " + values[0])
     }
 }

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/EglCore.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/EglCore.kt
@@ -134,9 +134,7 @@ class EglCore {
             // called makeCurrent() before create?
             Log.d(TAG, "NOTE: makeCurrent w/o display")
         }
-        if (!EGL14.eglMakeCurrent(eglDisplay, eglSurface, eglSurface, eglContext)) {
-            throw Exception("eglMakeCurrent failed")
-        }
+        if (!EGL14.eglMakeCurrent(eglDisplay, eglSurface, eglSurface, eglContext)) throw Exception("EGL Current 설정 실패")
     }
 
     /**

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/EglWindowSurface.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/EglWindowSurface.kt
@@ -5,12 +5,12 @@ import android.view.Surface
 import java.lang.RuntimeException
 
 /**
- * Recordable EGL window surface.
+ * EGLSurface 중 WindowSurface (Pixmap, Pbuffer는 offscreen을 위한 surface)
  *
  *
  * It's good practice to explicitly release() the surface, preferably from a "finally" block.
  */
-class WindowSurface : EglSurfaceBase {
+class EglWindowSurface : EglSurfaceBase {
     private var mSurface: Surface? = null
     private var mReleaseSurface = false
 

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/Texture2dProgram.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/Texture2dProgram.kt
@@ -196,6 +196,8 @@ class Texture2dProgram(
         private const val TAG = "Texture2dProgramTAG"
 
         // Simple vertex shader, used for all programs.
+//        attribute로 들어간 aPostition과 aTextureCoord는 위에서 순서대로 넣어준 것이다
+//        varying은 fragment shader로 연결된다
         private val VERTEX_SHADER = ("uniform mat4 uMVPMatrix;\n" +
                 "uniform mat4 uTexMatrix;\n" +
                 "attribute vec4 aPosition;\n" +

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
@@ -198,7 +198,7 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
     override fun surfaceCreated(p0: SurfaceHolder) {
         Log.d(TAG, "surfaceCreated: surfaceHolder=$p0")
 
-        eglCore = EglCore(null, EglCore.FLAG_RECORDABLE)
+        eglCore = EglCore()
         displaySurface = WindowSurface(eglCore!!, p0.surface, false)
         displaySurface!!.makeCurrent()
 

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
@@ -3,6 +3,7 @@ package com.kotlinisgood.boomerang.ui.videodoodle
 import android.graphics.SurfaceTexture
 import android.media.MediaPlayer
 import android.opengl.GLES20
+import android.opengl.GLES30
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -21,7 +22,6 @@ import java.io.File
 import java.io.IOException
 import java.lang.RuntimeException
 import java.lang.ref.WeakReference
-import kotlin.system.measureNanoTime
 
 
 class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
@@ -45,6 +45,8 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
     private lateinit var mediaPlayer: MediaPlayer
     private var videoWidth = 0
     private var videoHeight = 0
+    private var width = 0
+    private var height = 0
     private var outputVideo: File? = null
 //    private var secondsVideo = 0f
 
@@ -207,7 +209,8 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
         surfaceTexture = SurfaceTexture(textureId)
         surfaceTexture!!.setOnFrameAvailableListener(this)
 
-        val width = binding.svMovie.width
+        width = binding.svMovie.width
+        height = binding.svMovie.height
 
         try {
             circularEncoder = CircularEncoder(width, width, 6000000, 30, 60, handler)
@@ -244,14 +247,9 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
     }
 
     private fun drawFrame() {
-        val width = binding.svMovie.width
-        val height = binding.svMovie.height
-
         displaySurface?.makeCurrent()
         surfaceTexture?.updateTexImage()
         surfaceTexture?.getTransformMatrix(mTmpMatrix)
-
-//        GLES20.glBindFramebuffer(GLES20.GL_FRAMEBUFFER, )
 
 //        width, height가 videoWidth, VideoHeight보다 더 크다는 가정하에 함. 그 외의 경우도 만들어야 함!
 //        SurfaceView에 그리기
@@ -264,26 +262,29 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
         }
         fullFrameBlit?.drawFrame(textureId, mTmpMatrix)
         drawExtra(currentPoint, height)
-        displaySurface?.swapBuffers()
+//        displaySurface?.swapBuffers()
 
 //        저장하기
         circularEncoder.frameAvailableSoon()
-        encoderSurface?.makeCurrent()
-        if (videoWidth > videoHeight) {
-            val adjustedHeight = (height * (videoHeight / videoWidth.toFloat())).toInt()
-            GLES20.glViewport(0, (height - adjustedHeight) / 2, width, adjustedHeight)
-        } else {
-            val adjustedWidth = (width * (videoWidth / videoHeight.toFloat())).toInt()
-            GLES20.glViewport((width - adjustedWidth) / 2, 0, adjustedWidth, height)
-        }
-        fullFrameBlit?.drawFrame(textureId, mTmpMatrix)
-        drawExtra(currentPoint, height)
+        encoderSurface?.makeCurrentReadFrom(displaySurface!!)
+//        if (videoWidth > videoHeight) {
+//            val adjustedHeight = (height * (videoHeight / videoWidth.toFloat())).toInt()
+//            GLES20.glViewport(0, (height - adjustedHeight) / 2, width, adjustedHeight)
+//        } else {
+//            val adjustedWidth = (width * (videoWidth / videoHeight.toFloat())).toInt()
+//            GLES20.glViewport((width - adjustedWidth) / 2, 0, adjustedWidth, height)
+//        }
+//        fullFrameBlit?.drawFrame(textureId, mTmpMatrix)
+//        drawExtra(currentPoint, height)
+        GLES30.glBlitFramebuffer(0, 0, displaySurface!!.width, displaySurface!!.height, 0, 0, displaySurface!!.width, displaySurface!!.height, GLES30.GL_COLOR_BUFFER_BIT, GLES30.GL_NEAREST)
         encoderSurface?.setPresentationTime(surfaceTexture!!.timestamp)
         encoderSurface?.swapBuffers()
+
+        displaySurface?.makeCurrent()
+        displaySurface?.swapBuffers()
     }
 
     private fun drawExtra(currentPoint: List<Pair<Int, Int>>, height: Int) {
-        val time = measureNanoTime {
             currentPoint.forEach {
                 GLES20.glClearColor(1f, 1f, 0f, 1f)
                 GLES20.glEnable(GLES20.GL_SCISSOR_TEST)
@@ -291,8 +292,6 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
                 GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT)
                 GLES20.glDisable(GLES20.GL_SCISSOR_TEST)
             }
-        }
-        println(time)
     }
 
     companion object {

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
@@ -2,7 +2,6 @@ package com.kotlinisgood.boomerang.ui.videodoodle
 
 import android.graphics.SurfaceTexture
 import android.media.MediaPlayer
-import android.net.Uri
 import android.opengl.GLES20
 import android.os.Bundle
 import android.os.Handler
@@ -34,8 +33,8 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
     private val path by lazy { args.videoPath }
 
     private var eglCore: EglCore? = null
-    private var displaySurface: WindowSurface? = null
-    private var encoderSurface: WindowSurface? = null
+    private var displaySurface: EglWindowSurface? = null
+    private var encoderSurface: EglWindowSurface? = null
     private var surfaceTexture: SurfaceTexture? = null
     private lateinit var surfaceView: SurfaceView
     private var textureId = 0
@@ -198,8 +197,9 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
     override fun surfaceCreated(p0: SurfaceHolder) {
         Log.d(TAG, "surfaceCreated: surfaceHolder=$p0")
 
+//        EGL 설정
         eglCore = EglCore()
-        displaySurface = WindowSurface(eglCore!!, p0.surface, false)
+        displaySurface = EglWindowSurface(eglCore!!, p0.surface, false)
         displaySurface!!.makeCurrent()
 
         fullFrameBlit = FullFrameRect(Texture2dProgram(Texture2dProgram.ProgramType.TEXTURE_EXT))
@@ -214,7 +214,7 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
         } catch (e: IOException) {
             throw RuntimeException(e)
         }
-        encoderSurface = WindowSurface(eglCore!!, circularEncoder.inputSurface, true)
+        encoderSurface = EglWindowSurface(eglCore!!, circularEncoder.inputSurface, true)
     }
 
     private fun playVideoAlt() {


### PR DESCRIPTION
## Overview
- `glBlitFrameBuffer()`를 적용하여 기존에 두 번 렌더링 하던 것을 한 번만 렌더링하고 FrameBuffer Object를 복사하도록 수정
- EglCore의 코드를 EGL 초기화 순서에 맞게 수정


