### PR TITLE
[모두의 메모 작성 화면] MediaPlayer 에러 해결

### DIFF
--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
@@ -127,7 +127,8 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
         surfaceView.holder.addCallback(this)
 
         handler = MainHandler(this)
-        outputVideo = File(requireContext().filesDir, "outputVideo.mp4")
+        val currentUnixTime = System.currentTimeMillis()
+        outputVideo = File(requireContext().filesDir, "${currentUnixTime}.mp4")
 
         binding.btnPlay.setOnClickListener {
             playVideoAlt()

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
@@ -48,7 +48,12 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
     private var width = 0
     private var height = 0
     private var outputVideo: File? = null
-//    private var secondsVideo = 0f
+
+    //    private var secondsVideo = 0f
+    private var viewportX = 0
+    private var viewportY = 0
+    private var viewportWidth = 0
+    private var viewportHeight = 0
 
     private lateinit var handler: MainHandler
 
@@ -218,10 +223,25 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
         width = binding.svMovie.width
         height = binding.svMovie.height
 
+        //        width, height가 videoWidth, VideoHeight보다 더 크다는 가정하에 함. 그 외의 경우도 만들어야 함!
+        if (videoWidth > videoHeight) {
+            val adjustedHeight = (height * (videoHeight / videoWidth.toFloat())).toInt()
+            viewportX = 0
+            viewportY = (height - adjustedHeight) / 2
+            viewportWidth = width
+            viewportHeight = adjustedHeight
+        } else {
+            val adjustedWidth = (width * (videoWidth / videoHeight.toFloat())).toInt()
+            viewportX = (width - adjustedWidth) / 2
+            viewportY = 0
+            viewportWidth = adjustedWidth
+            viewportHeight = height
+        }
+
         try {
             circularEncoder = CircularEncoder(width, width, 6000000, 30, 60, handler)
         } catch (e: IOException) {
-            throw RuntimeException(e)
+            throw Exception(e)
         }
         encoderSurface = EglWindowSurface(eglCore!!, circularEncoder.inputSurface, true)
     }
@@ -246,51 +266,58 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
     }
 
     private fun drawFrame() {
-        displaySurface?.makeCurrent()
         surfaceTexture?.updateTexImage()
         surfaceTexture?.getTransformMatrix(mTmpMatrix)
 
-//        width, height가 videoWidth, VideoHeight보다 더 크다는 가정하에 함. 그 외의 경우도 만들어야 함!
 //        SurfaceView에 그리기
-        if (videoWidth > videoHeight) {
-            val adjustedHeight = (height * (videoHeight / videoWidth.toFloat())).toInt()
-            GLES20.glViewport(0, (height - adjustedHeight) / 2, width, adjustedHeight)
-        } else {
-            val adjustedWidth = (width * (videoWidth / videoHeight.toFloat())).toInt()
-            GLES20.glViewport((width - adjustedWidth) / 2, 0, adjustedWidth, height)
-        }
+        GLES20.glViewport(viewportX, viewportY, viewportWidth, viewportHeight)
         fullFrameBlit?.drawFrame(textureId, mTmpMatrix)
-        drawExtra(currentPoint, height)
-//        displaySurface?.swapBuffers()
+        drawLine(currentPoint, height)
 
-//        저장하기
-        circularEncoder.frameAvailableSoon()
-        encoderSurface?.makeCurrentReadFrom(displaySurface!!)
-//        if (videoWidth > videoHeight) {
-//            val adjustedHeight = (height * (videoHeight / videoWidth.toFloat())).toInt()
-//            GLES20.glViewport(0, (height - adjustedHeight) / 2, width, adjustedHeight)
-//        } else {
-//            val adjustedWidth = (width * (videoWidth / videoHeight.toFloat())).toInt()
-//            GLES20.glViewport((width - adjustedWidth) / 2, 0, adjustedWidth, height)
-//        }
-//        fullFrameBlit?.drawFrame(textureId, mTmpMatrix)
-//        drawExtra(currentPoint, height)
-        GLES30.glBlitFramebuffer(0, 0, displaySurface!!.width, displaySurface!!.height, 0, 0, displaySurface!!.width, displaySurface!!.height, GLES30.GL_COLOR_BUFFER_BIT, GLES30.GL_NEAREST)
-        encoderSurface?.setPresentationTime(surfaceTexture!!.timestamp)
-        encoderSurface?.swapBuffers()
+        if (eglCore?.glVersion == 3) {
+//        SurfaceView에 그릴 Framebuffer를 아직 swap하지 말고 인코딩 버퍼에 복사하고 둘 다 swap
+            encoderSurface?.makeCurrentReadFrom(displaySurface!!)
+            GLES30.glBlitFramebuffer(
+                0,
+                0,
+                displaySurface!!.width,
+                displaySurface!!.height,
+                0,
+                0,
+                displaySurface!!.width,
+                displaySurface!!.height,
+                GLES30.GL_COLOR_BUFFER_BIT,
+                GLES30.GL_NEAREST
+            )
+            circularEncoder.frameAvailableSoon()
+            encoderSurface?.setPresentationTime(surfaceTexture!!.timestamp)
+            encoderSurface?.swapBuffers()
 
-        displaySurface?.makeCurrent()
-        displaySurface?.swapBuffers()
+            displaySurface?.makeCurrent()
+            displaySurface?.swapBuffers()
+        } else {
+//            OpenGL ES 2.0일 경우. glBlitFramebuffer를 지원하지 않기에 그냥 두 번 그린다.
+            displaySurface?.swapBuffers()
+
+            encoderSurface?.makeCurrent()
+            GLES20.glViewport(viewportX, viewportY, viewportWidth, viewportHeight)
+            fullFrameBlit?.drawFrame(textureId, mTmpMatrix)
+            drawLine(currentPoint, height)
+            circularEncoder.frameAvailableSoon()
+            encoderSurface?.setPresentationTime(surfaceTexture!!.timestamp)
+            encoderSurface?.swapBuffers()
+            displaySurface?.makeCurrent()
+        }
     }
 
-    private fun drawExtra(currentPoint: List<Pair<Int, Int>>, height: Int) {
-            currentPoint.forEach {
-                GLES20.glClearColor(1f, 1f, 0f, 1f)
-                GLES20.glEnable(GLES20.GL_SCISSOR_TEST)
-                GLES20.glScissor(it.first, height - it.second, 15, 15)
-                GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT)
-                GLES20.glDisable(GLES20.GL_SCISSOR_TEST)
-            }
+    private fun drawLine(currentPoint: List<Pair<Int, Int>>, height: Int) {
+        currentPoint.forEach {
+            GLES20.glClearColor(1f, 1f, 0f, 1f)
+            GLES20.glEnable(GLES20.GL_SCISSOR_TEST)
+            GLES20.glScissor(it.first, height - it.second, 15, 15)
+            GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT)
+            GLES20.glDisable(GLES20.GL_SCISSOR_TEST)
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
@@ -209,6 +209,12 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
         surfaceTexture = SurfaceTexture(textureId)
         surfaceTexture!!.setOnFrameAvailableListener(this)
 
+        val surface = Surface(surfaceTexture)
+        mediaPlayer = MediaPlayer.create(context, path.toUri())
+        mediaPlayer.setSurface(surface)
+        videoWidth = mediaPlayer.videoWidth
+        videoHeight = mediaPlayer.videoHeight
+
         width = binding.svMovie.width
         height = binding.svMovie.height
 
@@ -221,14 +227,7 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
     }
 
     private fun playVideoAlt() {
-        val surface = Surface(surfaceTexture)
-
-        mediaPlayer = MediaPlayer.create(context, path.toUri())
-        mediaPlayer.setSurface(surface)
-        videoWidth = mediaPlayer.videoWidth
-        videoHeight = mediaPlayer.videoHeight
         mediaPlayer.start()
-        surface.release()
     }
 
     override fun surfaceChanged(p0: SurfaceHolder, p1: Int, p2: Int, p3: Int) {


### PR DESCRIPTION
## Related Issue
* Close: #55

## Overview

### MediaPlayer 에러 해결
- MediaPlayer를 초기화하지 않고 이 모두의 메모 fragment가 onPause() 상태로 넘어갈 때 MediaPlayer.stop()에서 에러가 발생하였던 것을 해결
- MediaPlayer의 초기화 코드가 Play 버튼을 눌렀을 때에만 실행되어서 해당 버튼을 누르지 않고 다른 화면으로 넘어가려 할 시 에러가 발생했던 것
- MediaPlayer의 초기화 코드를 onViewCreated()로 옮김

### OpenGL ES 버전에 따른 실행 분기 추가
- OpenGL ES 3.X 에서는 `glBlitFramebuffer()`를 사용하여 재생 Surface에 렌더링된 Framebuffer를 복사
- OpenGL ES 2.0 에서는 재생 Surface와 인코딩 Surface에 각각 렌더링

### 출력 동영상 이름 변경
- 기존까지 일괄적으로 "OutputVideo.mp4"로 지정되었던 것을 "${유닉스시간}.mp4"로 변경