### PR TITLE
[메모 화면] 모두의 메모 공유 기능 추가

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,10 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-feature android:glEsVersion="0x00020000" android:required="true" />
+
+    <uses-feature
+        android:glEsVersion="0x00020000"
+        android:required="true" />
 
     <application
         android:name=".MemoApplication"
@@ -16,23 +19,33 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Boomerang">
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="com.kotlinisgood.boomerang.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/filepaths" />
+        </provider>
         <activity
             android:name=".MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <action android:name="android.intent.action.SEARCH" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-            <meta-data android:name="android.app.searchable"
+            <meta-data
+                android:name="android.app.searchable"
                 android:resource="@xml/searchable" />
         </activity>
     </application>
 
     <queries>
         <intent>
-            <action
-                android:name="android.speech.RecognitionService" />
+            <action android:name="android.speech.RecognitionService" />
         </intent>
     </queries>
 </manifest>

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/Encoder.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/Encoder.kt
@@ -20,9 +20,9 @@ class Encoder(
     private var encoder: MediaCodec
     private val bufferInfo: MediaCodec.BufferInfo
     private var encodedFormat: MediaFormat? = null
-    val encoderBuffer: CircularEncoderBuffer =
+    private val encoderBuffer: CircularEncoderBuffer =
         CircularEncoderBuffer(bitrate, frameRate, desiredSpanSec)
-    lateinit var scope: CoroutineScope
+    private var scope: CoroutineScope = CoroutineScope(Dispatchers.Default)
 
     init {
         val format = MediaFormat.createVideoFormat("video/avc", width, height)

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
@@ -71,6 +71,7 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
         outputVideo = File(requireContext().filesDir, "${currentUnixTime}.mp4")
 
         binding.btnPlay.setOnClickListener {
+            binding.btnPlay.isEnabled = false
             playVideoAlt()
         }
 

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videoedit/VideoEditFragment.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videoedit/VideoEditFragment.kt
@@ -1,12 +1,15 @@
 package com.kotlinisgood.boomerang.ui.videoedit
 
+import android.content.Intent
 import android.media.MediaPlayer
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
+import androidx.core.content.FileProvider
 import androidx.core.net.toUri
 import androidx.core.widget.doOnTextChanged
 import androidx.databinding.DataBindingUtil
@@ -24,6 +27,7 @@ import com.kotlinisgood.boomerang.databinding.FragmentVideoEditBinding
 import com.kotlinisgood.boomerang.ui.videodoodlelight.SubVideo
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.*
+import java.io.File
 
 @AndroidEntryPoint
 class VideoEditFragment : Fragment() {
@@ -60,6 +64,7 @@ class VideoEditFragment : Fragment() {
         setViewModel()
         setVideoView()
         setPlayer()
+        setShareButton()
         setListener()
     }
 
@@ -77,6 +82,10 @@ class VideoEditFragment : Fragment() {
         }
     }
 
+    private fun setShareButton() {
+        if(args.subVideos.toList().isNotEmpty()) binding.btnShareMemo.visibility = View.GONE
+    }
+
     private fun setListener() {
         binding.etMemoTitle.doOnTextChanged { text, start, before, count ->
             viewModel.setTitle(text.toString())
@@ -85,6 +94,21 @@ class VideoEditFragment : Fragment() {
         binding.btnSaveMemo.setOnClickListener {
             viewModel.saveMemo()
             findNavController().navigate(R.id.action_videoEditLightFragment_to_homeFragment)
+        }
+
+        binding.btnShareMemo.setOnClickListener {
+            val fileName = args.baseVideo.split('/').last()
+            println(fileName)
+            val file = File(requireContext().filesDir, fileName)
+            val uri = FileProvider.getUriForFile(requireContext(), "com.kotlinisgood.boomerang.fileprovider", file)
+            val sendIntent: Intent = Intent().apply {
+                action = Intent.ACTION_SEND
+                putExtra(Intent.EXTRA_STREAM, uri)
+                type = "video/mp4"
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
+            val shareIntent = Intent.createChooser(sendIntent, null)
+            startActivity(shareIntent)
         }
     }
 

--- a/app/src/main/res/layout/fragment_video_edit.xml
+++ b/app/src/main/res/layout/fragment_video_edit.xml
@@ -37,12 +37,21 @@
             app:layout_constraintTop_toTopOf="@id/frame_video" />
 
         <EditText
-            android:hint="제목을 입력해주세요"
             android:id="@+id/et_memo_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:hint="제목을 입력해주세요"
             android:inputType="text"
             app:layout_constraintTop_toBottomOf="@id/frame_video" />
+
+        <Button
+            android:id="@+id/btn_share_memo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="32dp"
+            android:text="공유하기"
+            app:layout_constraintBottom_toTopOf="@id/btn_save_memo"
+            app:layout_constraintEnd_toEndOf="@id/btn_save_memo" />
 
         <Button
             android:id="@+id/btn_save_memo"
@@ -52,7 +61,6 @@
             android:text="저장하기"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />
-
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/xml/filepaths.xml
+++ b/app/src/main/res/xml/filepaths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <files-path
+        name="share"
+        path="/" />
+</paths>


### PR DESCRIPTION
## Related Issue
* Close: #80

## Overview

### 모두의 메모 공유 기능 추가
- FileProvider를 사용하여 file:// 로 시작하던 uri를 content://로 변경. 내부 파일 경로를 숨기고 임의로 지을 수 있음
- 암시적 인텐트로 video/mp4 파일을 수신할 앱들을 찾음 (Android Sharesheet가 나타나게 됨)

### 모두의 메모 작성시 에러 수정
- Play를 연달아 누르면 에러가 발생하므로 한 번만 누르고 disabled 처리

### 메모 편집 화면에서 다시 모두의 메모 작성 화면으로 돌아왔을 때 발생하는 에러 수정
- Encoder 클래스 내에서 coroutineScope를 미리 초기화하도록 수정
