### PR TITLE
[모두의 메모 화면] 생명 주기에 따라 작동하도록 개선, 기능 추가

### DIFF
--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
@@ -9,6 +9,9 @@ import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.view.*
+import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.content.ContextCompat
+import androidx.core.content.res.ResourcesCompat
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.databinding.DataBindingUtil
@@ -54,6 +57,7 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
 
     var currentPoint: MutableList<Pair<Int, Int>> = mutableListOf()
 
+    private var isPlaying = false
     var isSurfaceDestroyed = false
 
     override fun onCreateView(
@@ -92,7 +96,6 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
             binding.btnPlay.isEnabled = true
         }
 
-
         binding.btnPlay.setOnClickListener {
             playVideo()
         }
@@ -104,11 +107,10 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
         binding.svMovie.setOnTouchListener { _, motionEvent ->
             when (motionEvent.action) {
                 MotionEvent.ACTION_DOWN -> {
-                    drawLine(motionEvent.x.toInt(), motionEvent.y.toInt())
+                    if (isPlaying) drawLine(motionEvent.x.toInt(), motionEvent.y.toInt())
                 }
                 MotionEvent.ACTION_MOVE -> {
-                    fillSpace(motionEvent.x.toInt(), motionEvent.y.toInt())
-//                    drawLine(motionEvent.x.toInt(), motionEvent.y.toInt())
+                    if (isPlaying) fillSpace(motionEvent.x.toInt(), motionEvent.y.toInt())
                 }
                 MotionEvent.ACTION_UP -> {
                 }
@@ -151,7 +153,13 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
     override fun onPause() {
         super.onPause()
         mediaPlayer.pause()
-        binding.btnPlay.isEnabled = true
+        binding.btnPlay.setBackgroundDrawable(
+            ContextCompat.getDrawable(
+                requireContext(),
+                R.drawable.ic_baseline_play_arrow_24
+            )
+        )
+        isPlaying = false
     }
 
     override fun onDestroy() {
@@ -223,8 +231,26 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
     }
 
     private fun playVideo() {
-        mediaPlayer.start()
-        binding.btnPlay.isEnabled = false
+        if (isPlaying) {
+            mediaPlayer.pause()
+            binding.btnPlay.setBackgroundDrawable(
+                ContextCompat.getDrawable(
+                    requireContext(),
+                    R.drawable.ic_baseline_play_arrow_24
+                )
+            )
+            isPlaying = false
+        } else {
+            mediaPlayer.start()
+//            binding.btnPlay.isEnabled = false
+            binding.btnPlay.setBackgroundDrawable(
+                ContextCompat.getDrawable(
+                    requireContext(),
+                    R.drawable.ic_baseline_pause_24
+                )
+            )
+            isPlaying = true
+        }
     }
 
     override fun surfaceChanged(p0: SurfaceHolder, p1: Int, p2: Int, p3: Int) {

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
@@ -9,9 +9,7 @@ import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.view.*
-import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.content.ContextCompat
-import androidx.core.content.res.ResourcesCompat
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.databinding.DataBindingUtil
@@ -55,10 +53,11 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
     private var viewportWidth = 0
     private var viewportHeight = 0
 
-    var currentPoint: MutableList<Pair<Int, Int>> = mutableListOf()
-
+    //    x, y, 색상
+    private var currentPoint: MutableList<Triple<Int, Int, DrawColor>> = mutableListOf()
+    private var drawColor = DrawColor(red = 1f, green = 0f, blue = 0f)
     private var isPlaying = false
-    var isSurfaceDestroyed = false
+    private var isSurfaceDestroyed = false
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -118,19 +117,30 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
             binding.svMovie.performClick()
             true
         }
+
+        binding.rbRed.isChecked = true
+        binding.rgDoodleColor.setOnCheckedChangeListener { group, checkedId ->
+            when (checkedId) {
+                R.id.rb_red -> drawColor = DrawColor(red = 1f, green = 0f, blue = 0f)
+                R.id.rb_green -> drawColor = DrawColor(red = 0f, green = 1f, blue = 0f)
+                R.id.rb_blue -> drawColor = DrawColor(red = 0f, green = 0f, blue = 1f)
+                R.id.rb_yellow -> drawColor = DrawColor(red = 1f, green = 1f, blue = 0f)
+            }
+        }
     }
 
     private fun drawLine(x: Int, y: Int) {
-        currentPoint.add(Pair(x, y))
+        currentPoint.add(Triple(x, y, drawColor))
     }
 
     private fun fillSpace(x: Int, y: Int) {
         val last = currentPoint.last()
         for (i in 1..50) {
             currentPoint.add(
-                Pair(
+                Triple(
                     last.first + (x - last.first) * i / 100,
-                    last.second + (y - last.second) * i / 100
+                    last.second + (y - last.second) * i / 100,
+                    drawColor
                 )
             )
         }
@@ -312,9 +322,9 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
         }
     }
 
-    private fun drawLine(currentPoint: List<Pair<Int, Int>>, height: Int) {
+    private fun drawLine(currentPoint: List<Triple<Int, Int, DrawColor>>, height: Int) {
         currentPoint.forEach {
-            GLES20.glClearColor(1f, 1f, 0f, 1f)
+            GLES20.glClearColor(it.third.red, it.third.green, it.third.blue, 1f)
             GLES20.glEnable(GLES20.GL_SCISSOR_TEST)
             GLES20.glScissor(it.first, height - it.second, 15, 15)
             GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT)
@@ -326,3 +336,5 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
         private const val TAG = "VideoDoodleFragment"
     }
 }
+
+data class DrawColor(val red: Float, val green: Float, val blue: Float)

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
@@ -127,6 +127,10 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
                 R.id.rb_yellow -> drawColor = DrawColor(red = 1f, green = 1f, blue = 0f)
             }
         }
+
+        binding.btnErase.setOnClickListener {
+            currentPoint.clear()
+        }
     }
 
     private fun drawLine(x: Int, y: Int) {

--- a/app/src/main/res/drawable/ic_delete.xml
+++ b/app/src/main/res/drawable/ic_delete.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M6,19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2V7H6v12zM19,4h-3.5l-1,-1h-5l-1,1H5v2h14V4z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_video_doodle.xml
+++ b/app/src/main/res/layout/fragment_video_doodle.xml
@@ -47,6 +47,57 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/frame_movie" />
 
+        <RadioGroup
+            android:id="@+id/rg_doodle_color"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:orientation="horizontal"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/btn_play">
+
+            <com.google.android.material.radiobutton.MaterialRadioButton
+                android:id="@+id/rb_red"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:layout_marginEnd="4dp"
+                android:layout_weight="1"
+                android:background="@drawable/background_rb_red"
+                android:button="@null" />
+
+            <com.google.android.material.radiobutton.MaterialRadioButton
+                android:id="@+id/rb_green"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:layout_marginEnd="4dp"
+                android:layout_weight="1"
+                android:background="@drawable/background_rb_green"
+                android:button="@null" />
+
+            <com.google.android.material.radiobutton.MaterialRadioButton
+                android:id="@+id/rb_blue"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:layout_marginEnd="4dp"
+                android:layout_weight="1"
+                android:background="@drawable/background_rb_blue"
+                android:button="@null" />
+
+            <com.google.android.material.radiobutton.MaterialRadioButton
+                android:id="@+id/rb_yellow"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:layout_marginEnd="4dp"
+                android:layout_weight="1"
+                android:background="@drawable/background_rb_yellow"
+                android:button="@null" />
+        </RadioGroup>
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </layout>

--- a/app/src/main/res/layout/fragment_video_doodle.xml
+++ b/app/src/main/res/layout/fragment_video_doodle.xml
@@ -13,10 +13,12 @@
             android:id="@+id/btn_play"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:enabled="false"
             android:text="play"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
+
         <Button
             android:id="@+id/btn_capture"
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/fragment_video_doodle.xml
+++ b/app/src/main/res/layout/fragment_video_doodle.xml
@@ -9,25 +9,6 @@
         android:layout_height="match_parent"
         android:layout_margin="16dp">
 
-        <Button
-            android:id="@+id/btn_play"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:enabled="false"
-            android:text="play"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <Button
-            android:id="@+id/btn_capture"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="capture"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/btn_play"
-            app:layout_constraintTop_toTopOf="parent" />
-
         <com.kotlinisgood.boomerang.ui.videodoodle.AspectFrameLayout
             android:id="@+id/frame_movie"
             android:layout_width="0dp"
@@ -35,7 +16,7 @@
             app:layout_constraintDimensionRatio="H,1:1"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/btn_play">
+            app:layout_constraintTop_toTopOf="parent">
 
             <SurfaceView
                 android:id="@+id/sv_movie"
@@ -44,6 +25,27 @@
                 android:layout_gravity="center" />
 
         </com.kotlinisgood.boomerang.ui.videodoodle.AspectFrameLayout>
+
+        <androidx.appcompat.widget.AppCompatImageButton
+            android:id="@+id/btn_play"
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:layout_marginTop="16dp"
+            android:enabled="false"
+            android:background="@drawable/ic_baseline_play_arrow_24"
+            android:scaleType="centerCrop"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/frame_movie" />
+
+        <Button
+            android:id="@+id/btn_capture"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="capture"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/frame_movie" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_video_doodle.xml
+++ b/app/src/main/res/layout/fragment_video_doodle.xml
@@ -31,8 +31,8 @@
             android:layout_width="64dp"
             android:layout_height="64dp"
             android:layout_marginTop="16dp"
-            android:enabled="false"
             android:background="@drawable/ic_baseline_play_arrow_24"
+            android:enabled="false"
             android:scaleType="centerCrop"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -97,6 +97,17 @@
                 android:background="@drawable/background_rb_yellow"
                 android:button="@null" />
         </RadioGroup>
+
+        <Button
+            android:id="@+id/btn_erase"
+            style="@style/Widget.App.Button.OutlinedButton.IconOnly.Toggle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            app:icon="@drawable/ic_delete"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/rg_doodle_color" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
## Related Issue
* Close: #108 

## Overview
### 생명 주기에 따라 작동
Fragment의 onPause() 시에 동영상도 따라서 일시정지 되도록 수정하였고, SurfaceDestroyed() 된 후 다시 Fragment가 RESUME 상태로 돌아와 SurfaceCreated()가 호출되었을 때 다시 Surface를 연결시켜 다시 재생시킬 수 있게 됨

### 재생/일시정지 기능 구현
재생/일시정지 버튼을 만들었고, onPause()에서는 자동으로 일시정지 상태가 됩니다. 다시 재생 버튼을 누르면 이어져 재생됩니다. 일시정지 상태에서도 녹화는 계속됩니다(PresentationTime에 따라).

### 색상 선택 기능 구현
나만의 메모 기능과 같은 UI를 사용하여 사용자의 앱 기능 학습에 드는 시간을 줄였습니다.

### 지우개 버튼 구현
지우개 버튼을 클릭하면 작성했던 메모들이 모두 지워집니다.

## Screen Shot
<img src="https://user-images.githubusercontent.com/37128456/142822786-0004918b-53a3-4dbe-a1b6-2eaec97619c8.png" width = "400" />

