### PR TITLE
[오픈소스 라이선스 화면] 오픈소스 라이선스 표시 화면 구현

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id("kotlin-parcelize")
     id("androidx.navigation.safeargs")
     id('com.google.firebase.crashlytics')
+    id 'com.google.android.gms.oss-licenses-plugin'
 }
 
 android {
@@ -83,5 +84,7 @@ dependencies {
     //Lottie
     implementation "com.airbnb.android:lottie:$lottieVersion"
 
+    //OSS
+    implementation 'com.google.android.gms:play-services-oss-licenses:17.0.0'
 }
 apply plugin: "com.google.gms.google-services"

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/home/HomeFragment.kt
@@ -1,6 +1,7 @@
 package com.kotlinisgood.boomerang.ui.home
 
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -14,6 +15,7 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.StaggeredGridLayoutManager
+import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
 import com.kotlinisgood.boomerang.R
 import com.kotlinisgood.boomerang.databinding.FragmentHomeBinding
 import com.kotlinisgood.boomerang.util.AUDIO_MODE
@@ -138,9 +140,13 @@ class HomeFragment : Fragment() {
             dataBinding.drawerLayout.openDrawer(GravityCompat.START)
         }
         dataBinding.navigationView.setNavigationItemSelectedListener {
-            println(it)
 //            오픈소스 라이선스 제외하고 true로 해야함. 현재 선택한 메모 상태를 보여줄 수 있음
-            it.isChecked = true
+            when(it.itemId) {
+                R.id.navigation_drawer_option_open_source -> {
+                    startActivity(Intent(requireContext(), OssLicensesMenuActivity::class.java))
+                }
+            }
+//            it.isChecked = true
             dataBinding.drawerLayout.close()
             true
         }

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
@@ -129,7 +129,28 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
         }
 
         binding.btnErase.setOnClickListener {
+            currentPoint.forEach {
+                GLES20.glClearColor(0f, 0f, 0f, 1f)
+                GLES20.glEnable(GLES20.GL_SCISSOR_TEST)
+                GLES20.glScissor(it.first, height - it.second, 15, 15)
+                GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT)
+                GLES20.glDisable(GLES20.GL_SCISSOR_TEST)
+            }
             currentPoint.clear()
+        }
+
+        binding.tbVideoDoodle.setNavigationOnClickListener {
+            requireActivity().onBackPressed()
+        }
+
+        binding.tbVideoDoodle.setOnMenuItemClickListener {
+            when (it.itemId) {
+                R.id.menu_video_selection_completion -> {
+                    saveCompleted(circularEncoder.saveVideo(outputVideo))
+                    true
+                }
+                else -> false
+            }
         }
     }
 

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
@@ -99,10 +99,6 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
             playVideo()
         }
 
-        binding.btnCapture.setOnClickListener {
-            saveCompleted(circularEncoder.saveVideo(outputVideo))
-        }
-
         binding.svMovie.setOnTouchListener { _, motionEvent ->
             when (motionEvent.action) {
                 MotionEvent.ACTION_DOWN -> {

--- a/app/src/main/res/layout/fragment_video_doodle.xml
+++ b/app/src/main/res/layout/fragment_video_doodle.xml
@@ -6,17 +6,40 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_margin="16dp">
+        android:layout_height="match_parent">
+
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/container_video_doodle_appbar"
+            android:layout_width="0dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/colorSurface"
+            app:layout_constraintTop_toTopOf="parent" >
+
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/tb_video_doodle"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:background="?attr/colorSurface"
+                app:navigationIcon="@drawable/ic_arrow_back"
+                app:title="@string/fragment_video_selection_title"
+                app:titleTextAppearance="?attr/textAppearanceTitleLarge"
+                app:menu="@menu/menu_fragment_video_selection">
+
+            </com.google.android.material.appbar.MaterialToolbar>
+
+        </com.google.android.material.appbar.AppBarLayout>
 
         <com.kotlinisgood.boomerang.ui.videodoodle.AspectFrameLayout
             android:id="@+id/frame_movie"
             android:layout_width="0dp"
             android:layout_height="0dp"
+            android:layout_margin="16dp"
             app:layout_constraintDimensionRatio="H,1:1"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            app:layout_constraintTop_toBottomOf="@id/container_video_doodle_appbar">
 
             <SurfaceView
                 android:id="@+id/sv_movie"
@@ -43,6 +66,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
+            android:layout_marginEnd="16dp"
             android:text="capture"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/frame_movie" />

--- a/app/src/main/res/layout/fragment_video_doodle.xml
+++ b/app/src/main/res/layout/fragment_video_doodle.xml
@@ -61,16 +61,6 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/frame_movie" />
 
-        <Button
-            android:id="@+id/btn_capture"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:layout_marginEnd="16dp"
-            android:text="capture"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/frame_movie" />
-
         <RadioGroup
             android:id="@+id/rg_doodle_color"
             android:layout_width="wrap_content"

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ buildscript {
         classpath 'com.google.gms:google-services:4.3.10'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
+
+        classpath 'com.google.android.gms:oss-licenses-plugin:0.10.4'
     }
 }
 


### PR DESCRIPTION
## Related Issue
* Close: #68 

## Overview

### 오픈소스 라이선스 화면 구현
구글에서 제공하는 [오픈소스 라이선스 플러그인](https://github.com/google/play-services-plugins/tree/master/oss-licenses-plugin) 으로 실행. 사용한 모든 라이브러리들에 대해 라이선스를 표시하는 액티비티를 실행시킴

### 지우개 기능이 영상 외 검은색 화면 부분에서는 작동하지 않던 기능 수정


## Screen Shot

| List | License |
| :---: | :---: |
|![image](https://user-images.githubusercontent.com/37128456/142887141-8b7f52b4-487b-4c56-8d62-7ccab9e8d220.png)|![image](https://user-images.githubusercontent.com/37128456/142887159-f555a70e-119d-4e9b-abdf-18a1d7fa9d9d.png)|
