### PR TITLE
[Bugfix] Uri 대응

### DIFF
--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
@@ -7,6 +7,7 @@ import android.opengl.GLES20
 import android.opengl.GLES30
 import android.os.Build
 import android.os.Bundle
+import android.provider.MediaStore
 import android.util.Log
 import android.view.*
 import androidx.core.content.ContextCompat
@@ -81,19 +82,7 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
         val currentUnixTime = System.currentTimeMillis()
         outputVideo = File(requireContext().filesDir, "${currentUnixTime}.mp4")
 
-        val uri = if (Build.VERSION.SDK_INT >= 30) {
-            uriString.toUri()
-        } else {
-            Uri.fromFile(
-                File(
-                    UriUtil.getPathFromUri(
-                        requireActivity().contentResolver,
-                        uriString.toUri()
-                    )
-                )
-            )
-        }
-
+        val uri = uriString.toUri()
         mediaPlayer = MediaPlayer.create(context, uri)
 
         mediaPlayer.setOnPreparedListener {
@@ -177,7 +166,7 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
             Log.d(TAG, "Save Completed")
             val action =
                 VideoDoodleFragmentDirections.actionVideoDoodleFragmentToVideoEditLightFragment(
-                    outputVideo.absolutePath,
+                    outputVideo.toUri().toString(),
                     mutableListOf<SubVideo>().toTypedArray(),
                     true
                 )

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodlelight/VideoDoodleLightFragment.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodlelight/VideoDoodleLightFragment.kt
@@ -105,12 +105,12 @@ class VideoDoodleLightFragment : Fragment() {
         player = ExoPlayer.Builder(requireContext()).build()
         binding.exoplayer.player = player
         binding.pcvVideoDoodleLight.player = player
-        val uri = if (Build.VERSION.SDK_INT >= 29 ) {
-            uriString.toUri()
-        } else {
-            Uri.fromFile(File(UriUtil.getPathFromUri(requireActivity().contentResolver, uriString.toUri())))
-        }
-
+//        val uri = if (Build.VERSION.SDK_INT >= 29 ) {
+//            uriString.toUri()
+//        } else {
+//            Uri.fromFile(File(UriUtil.getPathFromUri(requireActivity().contentResolver, uriString.toUri())))
+//        }
+        val uri = uriString.toUri()
         val mediaItem = MediaItem.fromUri(uri)
         player.setMediaItem(mediaItem)
         player.addListener(playerListener)


### PR DESCRIPTION
## Overview
1. content uri로 원본 영상을 틀고 이후 파일이 저장된 후에는 file uri로 관리
2. 원본 영상을 copy할 때 안드로이드 버전 29인 경우에는 Scoped Storage 정책때문에 MediaStore로 파일을 복사한다


버전별 Uri 대응 및 Scoped Storage 대응이 잘못 되어있어서 수정하였다.