### PR TITLE
[모두의 메모] 화면 비율에 맞게 출력, 린트 검사 결과 수정

### DIFF
--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/AspectFrameLayout.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/AspectFrameLayout.kt
@@ -72,10 +72,12 @@ class AspectFrameLayout : FrameLayout {
             } else {
                 if (aspectDiff > 0) {
                     // limited by narrow width; restrict height
-                    initialHeight = (initialWidth / mTargetAspect).toInt()
+                    val preHeight = (initialWidth / mTargetAspect).toInt()
+                    initialHeight = preHeight - (preHeight % 16)
                 } else {
                     // limited by short height; restrict width
-                    initialWidth = (initialHeight * mTargetAspect).toInt()
+                    val preWidth = (initialHeight * mTargetAspect).toInt()
+                    initialWidth = preWidth - (preWidth % 16)
                 }
                 Log.d(
                     TAG, "new size=" + initialWidth + "x" + initialHeight + " + padding " +
@@ -83,8 +85,10 @@ class AspectFrameLayout : FrameLayout {
                 )
                 initialWidth += horizPadding
                 initialHeight += vertPadding
-                exactWidthMeasureSpec = MeasureSpec.makeMeasureSpec(initialWidth, MeasureSpec.EXACTLY)
-                exactHeightMeasureSpec = MeasureSpec.makeMeasureSpec(initialHeight, MeasureSpec.EXACTLY)
+                exactWidthMeasureSpec =
+                    MeasureSpec.makeMeasureSpec(initialWidth, MeasureSpec.EXACTLY)
+                exactHeightMeasureSpec =
+                    MeasureSpec.makeMeasureSpec(initialHeight, MeasureSpec.EXACTLY)
             }
         }
 

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/AspectFrameLayout.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/AspectFrameLayout.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.util.Log
 import android.widget.FrameLayout
+import kotlin.math.abs
 
 /**
  * Layout that adjusts to maintain a specific aspect ratio.
@@ -31,6 +32,11 @@ class AspectFrameLayout : FrameLayout {
         }
     }
 
+    override fun performClick(): Boolean {
+        super.performClick()
+        return true
+    }
+
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         var exactWidthMeasureSpec = widthMeasureSpec
         var exactHeightMeasureSpec = heightMeasureSpec
@@ -55,7 +61,7 @@ class AspectFrameLayout : FrameLayout {
             initialHeight -= vertPadding
             val viewAspectRatio = initialWidth.toDouble() / initialHeight
             val aspectDiff = mTargetAspect / viewAspectRatio - 1
-            if (Math.abs(aspectDiff) < 0.01) {
+            if (abs(aspectDiff) < 0.01) {
                 // We're very close already.  We don't want to risk switching from e.g. non-scaled
                 // 1280x720 to scaled 1280x719 because of some floating-point round-off error,
                 // so if we're really close just leave it alone.

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/DrawColor.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/DrawColor.kt
@@ -1,0 +1,3 @@
+package com.kotlinisgood.boomerang.ui.videodoodle
+
+data class DrawColor(val red: Float, val green: Float, val blue: Float)

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/Drawable2d.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/Drawable2d.kt
@@ -1,6 +1,5 @@
 package com.kotlinisgood.boomerang.ui.videodoodle
 
-import java.lang.RuntimeException
 import java.nio.FloatBuffer
 
 /**
@@ -153,7 +152,6 @@ class Drawable2d(shape: Prefab) {
                 vertexStride = coordsPerVertex * SIZEOF_FLOAT
                 vertexCount = FULL_RECTANGLE_COORDS.size / coordsPerVertex
             }
-            else -> throw RuntimeException("Unknown shape $shape")
         }
         texCoordStride = 2 * SIZEOF_FLOAT
         mPrefab = shape

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/Egl.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/Egl.kt
@@ -240,32 +240,32 @@ class Egl {
     private fun getEglContext() {
         getEglConfig(3)
         if (eglConfig != null) {
-            val attrib3_list = intArrayOf(
+            val gl3Setup = intArrayOf(
                 EGL14.EGL_CONTEXT_CLIENT_VERSION, 3,
                 EGL14.EGL_NONE
             )
             val context = EGL14.eglCreateContext(
                 eglDisplay, eglConfig, EGL14.EGL_NO_CONTEXT,
-                attrib3_list, 0
+                gl3Setup, 0
             )
             if (EGL14.eglGetError() == EGL14.EGL_SUCCESS) {
-                Log.d(TAG, "Got GLES 3 config");
+                Log.d(TAG, "Got GLES 3 config")
                 eglContext = context
                 glVersion = 3
             }
         } else {
             getEglConfig(2)
             if (eglConfig == null) throw Exception("Unable to find a suitable EGLConfig")
-            val attrib2_list = intArrayOf(
+            val gl2Setup = intArrayOf(
                 EGL14.EGL_CONTEXT_CLIENT_VERSION, 2,
                 EGL14.EGL_NONE
             )
             val context = EGL14.eglCreateContext(
                 eglDisplay, eglConfig, EGL14.EGL_NO_CONTEXT,
-                attrib2_list, 0
+                gl2Setup, 0
             )
             checkEglError("eglCreateContext")
-            Log.d(TAG, "Got GLES 2 config");
+            Log.d(TAG, "Got GLES 2 config")
             eglContext = context
             glVersion = 2
         }

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/EglWindowSurface.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/EglWindowSurface.kt
@@ -40,8 +40,8 @@ class EglWindowSurface(private val egl: Egl, private var surface: Surface?) {
 
         // Don't cache width/height here, because the size of the underlying surface can change
         // out from under us (see e.g. HardwareScalerActivity).
-        mWidth = egl.querySurface(eglSurface, EGL14.EGL_WIDTH);
-        mHeight = egl.querySurface(eglSurface, EGL14.EGL_HEIGHT);
+        mWidth = egl.querySurface(eglSurface, EGL14.EGL_WIDTH)
+        mHeight = egl.querySurface(eglSurface, EGL14.EGL_HEIGHT)
     }
 
     /**

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/FullFrameRect.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/FullFrameRect.kt
@@ -4,9 +4,9 @@ package com.kotlinisgood.boomerang.ui.videodoodle
  * This class essentially represents a viewport-sized sprite that will be rendered with
  * a texture, usually from an external source like the camera or video decoder.
  */
-class FullFrameRect(program: Texture2dProgram?) {
+class FullFrameRect {
     private val mRectDrawable: Drawable2d = Drawable2d(Drawable2d.Prefab.FULL_RECTANGLE)
-    private var mProgram: Texture2dProgram?
+    private var program = Texture2dProgram()
 
     /**
      * Releases resources.
@@ -18,36 +18,15 @@ class FullFrameRect(program: Texture2dProgram?) {
      * can pass a flag that will tell this function to skip any EGL-context-specific cleanup.
      */
     fun release(doEglCleanup: Boolean) {
-        if (mProgram != null) {
-            if (doEglCleanup) {
-                mProgram!!.release()
-            }
-            mProgram = null
-        }
+        if (doEglCleanup) program.release()
     }
 
-    /**
-     * Returns the program currently in use.
-     */
-    val program: Texture2dProgram?
-        get() = mProgram
-
-    /**
-     * Changes the program.  The previous program will be released.
-     *
-     *
-     * The appropriate EGL context must be current.
-     */
-    fun changeProgram(program: Texture2dProgram?) {
-        mProgram?.release()
-        mProgram = program
-    }
 
     /**
      * Creates a texture object suitable for use with drawFrame().
      */
     fun createTextureObject(): Int {
-        return mProgram!!.createTextureObject()
+        return program.createTextureObject()
     }
 
     /**
@@ -55,22 +34,12 @@ class FullFrameRect(program: Texture2dProgram?) {
      */
     fun drawFrame(textureId: Int, texMatrix: FloatArray?) {
         // Use the identity matrix for MVP so our 2x2 FULL_RECTANGLE covers the viewport.
-        mProgram?.draw(
+        program.draw(
             GlUtil.IDENTITY_MATRIX, mRectDrawable.vertexArray, 0,
             mRectDrawable.vertexCount, mRectDrawable.coordsPerVertex,
             mRectDrawable.vertexStride,
             texMatrix, mRectDrawable.texCoordArray, textureId,
             mRectDrawable.texCoordStride
         )
-    }
-
-    /**
-     * Prepares the object.
-     *
-     * @param program The program to use.  FullFrameRect takes ownership, and will release
-     * the program when no longer needed.
-     */
-    init {
-        mProgram = program
     }
 }

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/GlUtil.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/GlUtil.kt
@@ -1,7 +1,6 @@
 package com.kotlinisgood.boomerang.ui.videodoodle
 
 import android.opengl.GLES20
-import android.opengl.GLES30
 import android.opengl.Matrix
 import android.util.Log
 import java.lang.RuntimeException
@@ -17,7 +16,7 @@ object GlUtil {
     private const val TAG = "GlUtilTAG"
 
     /** Identity matrix for general use.  Don't modify or life will get weird.  */
-    val IDENTITY_MATRIX: FloatArray
+    val IDENTITY_MATRIX: FloatArray = FloatArray(16)
     private const val SIZEOF_FLOAT = 4
 
     /**
@@ -102,46 +101,6 @@ object GlUtil {
     }
 
     /**
-     * Creates a texture from raw data.
-     *
-     * @param data Image data, in a "direct" ByteBuffer.
-     * @param width Texture width, in pixels (not bytes).
-     * @param height Texture height, in pixels.
-     * @param format Image data format (use constant appropriate for glTexImage2D(), e.g. GL_RGBA).
-     * @return Handle to texture.
-     */
-    fun createImageTexture(data: ByteBuffer?, width: Int, height: Int, format: Int): Int {
-        val textureHandles = IntArray(1)
-        val textureHandle: Int
-        GLES20.glGenTextures(1, textureHandles, 0)
-        textureHandle = textureHandles[0]
-        checkGlError("glGenTextures")
-
-        // Bind the texture handle to the 2D texture target.
-        GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, textureHandle)
-
-        // Configure min/mag filtering, i.e. what scaling method do we use if what we're rendering
-        // is smaller or larger than the source image.
-        GLES20.glTexParameteri(
-            GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MIN_FILTER,
-            GLES20.GL_LINEAR
-        )
-        GLES20.glTexParameteri(
-            GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MAG_FILTER,
-            GLES20.GL_LINEAR
-        )
-        checkGlError("loadImageTexture")
-
-        // Load the data from the buffer into the texture handle.
-        GLES20.glTexImage2D(
-            GLES20.GL_TEXTURE_2D,  /*level*/0, format,
-            width, height,  /*border*/0, format, GLES20.GL_UNSIGNED_BYTE, data
-        )
-        checkGlError("loadImageTexture")
-        return textureHandle
-    }
-
-    /**
      * Allocates a direct float buffer, and populates it with the float array data.
      */
     fun createFloatBuffer(coords: FloatArray): FloatBuffer {
@@ -154,27 +113,7 @@ object GlUtil {
         return fb
     }
 
-    /**
-     * Writes GL version info to the log.
-     */
-    fun logVersionInfo() {
-        Log.i(TAG, "vendor  : " + GLES20.glGetString(GLES20.GL_VENDOR))
-        Log.i(TAG, "renderer: " + GLES20.glGetString(GLES20.GL_RENDERER))
-        Log.i(TAG, "version : " + GLES20.glGetString(GLES20.GL_VERSION))
-        if (false) {
-            val values = IntArray(1)
-            GLES30.glGetIntegerv(GLES30.GL_MAJOR_VERSION, values, 0)
-            val majorVersion = values[0]
-            GLES30.glGetIntegerv(GLES30.GL_MINOR_VERSION, values, 0)
-            val minorVersion = values[0]
-            if (GLES30.glGetError() == GLES30.GL_NO_ERROR) {
-                Log.i(TAG, "iversion: $majorVersion.$minorVersion")
-            }
-        }
-    }
-
     init {
-        IDENTITY_MATRIX = FloatArray(16)
         Matrix.setIdentityM(IDENTITY_MATRIX, 0)
     }
 }

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/Texture2dProgram.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/Texture2dProgram.kt
@@ -3,7 +3,6 @@ package com.kotlinisgood.boomerang.ui.videodoodle
 import android.opengl.GLES11Ext
 import android.opengl.GLES20
 import android.util.Log
-import java.lang.IllegalArgumentException
 import java.lang.RuntimeException
 import java.nio.FloatBuffer
 
@@ -165,7 +164,7 @@ class Texture2dProgram
         // Simple vertex shader, used for all programs.
 //        attribute로 들어간 aPostition과 aTextureCoord는 위에서 순서대로 넣어준 것이다
 //        varying은 fragment shader로 연결된다
-        private val VERTEX_SHADER = ("uniform mat4 uMVPMatrix;\n" +
+        private const val VERTEX_SHADER = ("uniform mat4 uMVPMatrix;\n" +
                 "uniform mat4 uTexMatrix;\n" +
                 "attribute vec4 aPosition;\n" +
                 "attribute vec4 aTextureCoord;\n" +
@@ -175,17 +174,9 @@ class Texture2dProgram
                 "    vTextureCoord = (uTexMatrix * aTextureCoord).xy;\n" +
                 "}\n")
 
-        // Simple fragment shader for use with "normal" 2D textures.
-        private val FRAGMENT_SHADER_2D = ("precision mediump float;\n" +
-                "varying vec2 vTextureCoord;\n" +
-                "uniform sampler2D sTexture;\n" +
-                "void main() {\n" +
-                "    gl_FragColor = texture2D(sTexture, vTextureCoord);\n" +
-                "}\n")
-
         // Simple fragment shader for use with external 2D textures (e.g. what we get from
         // SurfaceTexture).
-        private val FRAGMENT_SHADER_EXT = ("#extension GL_OES_EGL_image_external : require\n" +
+        private const val FRAGMENT_SHADER_EXT = ("#extension GL_OES_EGL_image_external : require\n" +
                 "precision mediump float;\n" +
                 "varying vec2 vTextureCoord;\n" +
                 "uniform samplerExternalOES sTexture;\n" +

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
@@ -73,7 +73,7 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
         savedInstanceState: Bundle?
     ): View {
         _dataBinding =
-            DataBindingUtil.inflate(inflater, R.layout.fragment_video_doodle, container, false)
+            FragmentVideoDoodleBinding.inflate(inflater, container, false)
 //        val mmr = MediaMetadataRetriever()
 //        mmr.setDataSource(UriUtil.getPathFromUri(requireContext().contentResolver, uriString.toUri()))
 //        val testHeight =

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
@@ -30,7 +30,7 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
     private var _dataBinding: FragmentVideoDoodleBinding? = null
     private val dataBinding get() = _dataBinding!!
 
-    private val viewModel: VideoDoodleViewModel by viewModels()
+    private val videoDoodleViewModel: VideoDoodleViewModel by viewModels()
 
     private val args: VideoDoodleFragmentArgs by navArgs()
     private val uriString by lazy { args.videoPath }
@@ -113,7 +113,7 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
             playVideo()
         })
 
-        dataBinding.svMovie.setOnTouchListener { _, motionEvent ->
+        dataBinding.frameMovie.setOnTouchListener { _, motionEvent ->
             when (motionEvent.action) {
                 MotionEvent.ACTION_DOWN -> {
                     if (isPlaying) drawLine(motionEvent.x.toInt(), motionEvent.y.toInt())
@@ -124,7 +124,7 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
                 MotionEvent.ACTION_UP -> {
                 }
             }
-            dataBinding.svMovie.performClick()
+            dataBinding.frameMovie.performClick()
             true
         }
 
@@ -157,10 +157,8 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
             when (it.itemId) {
                 R.id.menu_video_selection_completion -> {
                     compositeDisposable.add(it.throttle(1000, TimeUnit.MILLISECONDS) {
-//                        saveCompleted(circularEncoder.saveVideo(outputVideo))
-//                        saveCompleted(circularEncoder.saveVideo(outputVideo))
-                        viewModel.encoder.muxerStop()
-                        saveCompleted(0)
+                        videoDoodleViewModel.encoder.muxerStop()
+                        saveCompleted()
                     })
                 }
             }
@@ -184,29 +182,23 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
         }
     }
 
-    private fun saveCompleted(status: Int) {
-        if (status == 0) {
-            Log.d(TAG, "Save Completed")
-            val action =
-                VideoDoodleFragmentDirections.actionVideoDoodleFragmentToVideoEditLightFragment(
-                    outputVideo.toUri().toString(),
-                    mutableListOf<SubVideo>().toTypedArray(),
-                    true
-                )
-            findNavController().navigate(action)
-        } else {
-            Log.d(TAG, "Save Failed")
-        }
+    private fun saveCompleted() {
+        Log.d(TAG, "Save Completed")
+        val action =
+            VideoDoodleFragmentDirections.actionVideoDoodleFragmentToVideoEditLightFragment(
+                outputVideo.toUri().toString(),
+                mutableListOf<SubVideo>().toTypedArray(),
+                true
+            )
+        findNavController().navigate(action)
     }
 
     override fun onPause() {
         super.onPause()
         mediaPlayer.pause()
-        dataBinding.btnPlay.setBackgroundDrawable(
-            ContextCompat.getDrawable(
-                requireContext(),
-                R.drawable.ic_baseline_play_arrow_24
-            )
+        dataBinding.btnPlay.background = ContextCompat.getDrawable(
+            requireContext(),
+            R.drawable.ic_doodle_play
         )
         isPlaying = false
     }
@@ -235,7 +227,7 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
         displaySurface = EglWindowSurface(egl, p0.surface)
         displaySurface.makeCurrent()
 
-        fullFrameBlit = FullFrameRect(Texture2dProgram())
+        fullFrameBlit = FullFrameRect()
         textureId = fullFrameBlit.createTextureObject()
         surfaceTexture = SurfaceTexture(textureId)
         surfaceTexture.setOnFrameAvailableListener(this)
@@ -262,30 +254,26 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
             viewportHeight = height
         }
 
-        if (!viewModel.isEncoderWorking) {
-            viewModel.encoder = Encoder(width, height, 6000000, 30, outputVideo)
-            encoderSurface = EglWindowSurface(egl, viewModel.encoder.inputSurface)
+        if (!videoDoodleViewModel.isEncoderWorking) {
+            videoDoodleViewModel.encoder = Encoder(width, height, 6000000, 30, outputVideo)
+            encoderSurface = EglWindowSurface(egl, videoDoodleViewModel.encoder.inputSurface)
         }
-        viewModel.isEncoderWorking = true
+        videoDoodleViewModel.isEncoderWorking = true
     }
 
     private fun playVideo() {
         if (isPlaying) {
             mediaPlayer.pause()
-            dataBinding.btnPlay.setBackgroundDrawable(
-                ContextCompat.getDrawable(
-                    requireContext(),
-                    R.drawable.ic_doodle_play
-                )
+            dataBinding.btnPlay.background = ContextCompat.getDrawable(
+                requireContext(),
+                R.drawable.ic_doodle_play
             )
             isPlaying = false
         } else {
             mediaPlayer.start()
-            dataBinding.btnPlay.setBackgroundDrawable(
-                ContextCompat.getDrawable(
-                    requireContext(),
-                    R.drawable.ic_doodle_pause
-                )
+            dataBinding.btnPlay.background = ContextCompat.getDrawable(
+                requireContext(),
+                R.drawable.ic_doodle_pause
             )
             isPlaying = true
         }
@@ -330,7 +318,7 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
                 GLES30.GL_COLOR_BUFFER_BIT,
                 GLES30.GL_NEAREST
             )
-            viewModel.encoder.transferBuffer()
+            videoDoodleViewModel.encoder.transferBuffer()
             encoderSurface.setPresentationTime(surfaceTexture.timestamp)
             encoderSurface.swapBuffers()
 
@@ -344,7 +332,7 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
             GLES20.glViewport(0, 0, width, height)
             fullFrameBlit.drawFrame(textureId, mTmpMatrix)
             drawLine(currentPoint, height)
-            viewModel.encoder.transferBuffer()
+            videoDoodleViewModel.encoder.transferBuffer()
             encoderSurface.setPresentationTime(surfaceTexture.timestamp)
             encoderSurface.swapBuffers()
             displaySurface.makeCurrent()
@@ -365,5 +353,3 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
         private const val TAG = "VideoDoodleFragment"
     }
 }
-
-data class DrawColor(val red: Float, val green: Float, val blue: Float)

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
@@ -22,6 +22,7 @@ import com.kotlinisgood.boomerang.util.throttle
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import java.io.File
 import java.util.concurrent.TimeUnit
+import kotlin.math.floor
 
 
 class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
@@ -103,11 +104,11 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
         }
 
 //        실수부 값이 너무 커지지 않도록 끊어줘야 함
-//        val ratio = floor(mediaPlayer.videoWidth.toDouble()/mediaPlayer.videoHeight*10000)/10000.0
+        val ratio = floor(mediaPlayer.videoWidth.toDouble()/mediaPlayer.videoHeight*10000)/10000.0
 //        val ratio = 1.0000
-//        println("Before: $ratio")
+        println("Before: $ratio")
 //        dataBinding.frameMovie.setAspectRatio("%.4f".format(ratio).toDouble())
-//        dataBinding.frameMovie.setAspectRatio(ratio)
+        dataBinding.frameMovie.setAspectRatio(ratio)
 
         compositeDisposable.add(dataBinding.btnPlay.throttle(1000, TimeUnit.MILLISECONDS) {
             playVideo()

--- a/app/src/main/res/layout/fragment_video_doodle.xml
+++ b/app/src/main/res/layout/fragment_video_doodle.xml
@@ -31,19 +31,26 @@
 
         </com.google.android.material.appbar.AppBarLayout>
 
-        <FrameLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="320dp"
+            android:layout_height="wrap_content">
+
+        <FrameLayout
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             android:layout_marginHorizontal="@dimen/dp16"
             android:layout_marginTop="@dimen/dp16"
             android:background="@color/black"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintDimensionRatio="H, 1:1">
 
 
             <com.kotlinisgood.boomerang.ui.videodoodle.AspectFrameLayout
                 android:id="@+id/frame_movie"
                 android:layout_width="match_parent"
-                android:layout_height="240dp"
+                android:layout_height="match_parent"
                 android:layout_gravity="center">
 
                 <SurfaceView
@@ -55,6 +62,7 @@
             </com.kotlinisgood.boomerang.ui.videodoodle.AspectFrameLayout>
 
         </FrameLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/container_video_doodle_media_button"


### PR DESCRIPTION
## Related Issue
* Close: #141

## Overview
### 비율에 맞게 영상이 출력되지 않던 에러 수정
- 기존에는 화면 너비에 맞게 강제로 1:1로 영상을 출력, 인코딩하였음
- 이를 개선하여 원본 영상비에 가깝게 출력(단, 16의 배수에 맞게 출력해야 에러가 없으므로 나머지를 자름)
- 뒤의 영상 재생 화면과 일관성을 높이기 위해 화면 뒤를 검은색으로 출력

### 린트 검사 결과에 맞게 코드 개선
- Accessibility, Coding Convention 등을 SuppressLint를 사용하지 않고 권고에 맞게 수정

### 데이터바인딩 방식 수정
- DatabindingUtil.inflate -> Fragment~~Binding.inflate로 수정