### PR TITLE
불필요한 코드 제거

### DIFF
--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/Encoder.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/Encoder.kt
@@ -58,22 +58,15 @@ class Encoder(
                         mediaMuxer.start()
                         isMuxerStart = true
                     }
-                    in Int.MIN_VALUE until 0 -> {
-//                        에러 값들 음수로 되어있음. 여기서 에러 발생시 세부적으로 에러값 받아오자
-                        Log.d(TAG, "dequeOutputBufferError")
-                    }
                     else -> {
                         val encoderOutputBuffers = encoder.getOutputBuffer(encoderStatus)
-                        val encodedData = encoderOutputBuffers
-                            ?: throw Exception("encoderOutputBuffer[encoderStatus] is null")
+                            ?: throw Exception("MediaCodec.getOutputBuffer is null")
                         if (bufferInfo.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG != 0) bufferInfo.size =
                             0
                         if (bufferInfo.size != 0) {
-                            encodedData.position(bufferInfo.offset)
-                            encodedData.limit(bufferInfo.offset + bufferInfo.size)
                             if (isMuxerStart) mediaMuxer.writeSampleData(
                                 videoTrack,
-                                encodedData,
+                                encoderOutputBuffers,
                                 bufferInfo
                             )
                         }

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/Program.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/Program.kt
@@ -14,7 +14,6 @@ class Program {
     private var colorAdjustLoc = 0
     private val positionLoc: Int
     private val textureCoordLoc: Int
-    private var textureTarget = GLES11Ext.GL_TEXTURE_EXTERNAL_OES
     private lateinit var texOffset: FloatArray
 
     init {
@@ -78,7 +77,6 @@ class Program {
         val compiled = IntArray(1)
         GLES20.glGetShaderiv(shader, GLES20.GL_COMPILE_STATUS, compiled, 0)
         if (compiled[0] == 0) {
-            Log.e(TAG, "Could not compile shader $shaderType:")
             Log.e(TAG, " " + GLES20.glGetShaderInfoLog(shader))
             GLES20.glDeleteShader(shader)
             shader = 0
@@ -92,20 +90,12 @@ class Program {
         val texId = textures[0]
         GLES20.glBindTexture(textureTarget, texId)
         GLES20.glTexParameteri(
-            GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_MIN_FILTER,
+            textureTarget, GLES20.GL_TEXTURE_MIN_FILTER,
             GLES20.GL_NEAREST
         )
         GLES20.glTexParameteri(
-            GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_MAG_FILTER,
+            textureTarget, GLES20.GL_TEXTURE_MAG_FILTER,
             GLES20.GL_LINEAR
-        )
-        GLES20.glTexParameteri(
-            GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_WRAP_S,
-            GLES20.GL_CLAMP_TO_EDGE
-        )
-        GLES20.glTexParameteri(
-            GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_WRAP_T,
-            GLES20.GL_CLAMP_TO_EDGE
         )
         return texId
     }
@@ -167,6 +157,7 @@ class Program {
                     "    gl_FragColor = texture2D(sTexture, vTextureCoord);\n" +
                     "}\n")
 
+        private const val textureTarget = GLES11Ext.GL_TEXTURE_EXTERNAL_OES
         private const val TAG = "Texture2dProgram"
     }
 }

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
@@ -46,7 +46,7 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
     private lateinit var encoderSurface: WindowSurface
     private var textureId = 0
     private lateinit var fullFrameBlit: FullFrameRectangle
-    private val mTmpMatrix = FloatArray(16)
+    private val transformMatrix = FloatArray(16)
 
     private lateinit var mediaPlayer: MediaPlayer
     private var videoWidth = 0
@@ -279,12 +279,12 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
 
     private fun drawFrame() {
         surfaceTexture.updateTexImage()
-        surfaceTexture.getTransformMatrix(mTmpMatrix)
+        surfaceTexture.getTransformMatrix(transformMatrix)
 
 //        SurfaceView에 그리기
         GLES20.glViewport(0, 0, width, height)
         GLES20.glClearColor(0f, 0f, 0f, 1f)
-        fullFrameBlit.drawFrame(textureId, mTmpMatrix)
+        fullFrameBlit.drawFrame(textureId, transformMatrix)
         drawLine(currentPoint, height)
 
         if (egl.glVersion == 3) {
@@ -314,7 +314,7 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
 
             encoderSurface.makeCurrent()
             GLES20.glViewport(0, 0, width, height)
-            fullFrameBlit.drawFrame(textureId, mTmpMatrix)
+            fullFrameBlit.drawFrame(textureId, transformMatrix)
             drawLine(currentPoint, height)
             videoDoodleViewModel.encoder.transferBuffer()
             encoderSurface.setPresentationTime(surfaceTexture.timestamp)


### PR DESCRIPTION
- 텍스처 래핑 파라미터는 동영상 이미지 전체를 사각형에 입힐 때에는 필요하지 않다고 판단되어 제거하였습니다.
- 인코딩 과정에서 불필요한 코드를 제거하였습니다.
- `VideoDoodleFragment`에서 변환행렬의 변수명을 이해하기 쉽도록 수정하였습니다.
