### PR TITLE
[Refactor] OpenGL ES의 버퍼 사용, 인코더 I-Frame Interval 값 수정

### DIFF
--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/Encoder.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/Encoder.kt
@@ -12,8 +12,6 @@ import java.io.File
 class Encoder(
     width: Int,
     height: Int,
-    bitrate: Int,
-    frameRate: Int,
     outputVideo: File?
 ) {
     val inputSurface: Surface
@@ -26,7 +24,6 @@ class Encoder(
     private var videoTrack = -1
     private var isMuxerStart = false
 
-
     init {
         val format = MediaFormat.createVideoFormat("video/avc", width, height)
 
@@ -34,9 +31,9 @@ class Encoder(
             MediaFormat.KEY_COLOR_FORMAT,
             MediaCodecInfo.CodecCapabilities.COLOR_FormatSurface
         )
-        format.setInteger(MediaFormat.KEY_BIT_RATE, bitrate)
-        format.setInteger(MediaFormat.KEY_FRAME_RATE, frameRate)
-        format.setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, 1)
+        format.setInteger(MediaFormat.KEY_BIT_RATE, BIT_RATE)
+        format.setInteger(MediaFormat.KEY_FRAME_RATE, FRAME_RATE)
+        format.setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, I_FRAME_INTERVAL)
 
         encoder = MediaCodec.createEncoderByType("video/avc")
         encoder.configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
@@ -86,6 +83,8 @@ class Encoder(
     }
 
     companion object {
-        const val TAG = "Encoder"
+        private const val BIT_RATE = 6000000
+        private const val FRAME_RATE = 30
+        private const val I_FRAME_INTERVAL = 5
     }
 }

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/FullFrameRectangle.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/FullFrameRectangle.kt
@@ -15,11 +15,7 @@ class FullFrameRectangle {
 
     fun drawFrame(textureId: Int, texMatrix: FloatArray?) {
         program.draw(
-            matrix, rectangleVertex.vertexArray, 0,
-            rectangleVertex.vertexCount, 2,
-            rectangleVertex.vertexStride,
-            texMatrix, rectangleVertex.texCoordArray, textureId,
-            rectangleVertex.texCoordStride
+            matrix, rectangleVertex.vertexArray, texMatrix, rectangleVertex.texCoordArray, textureId
         )
     }
 }

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/RectangleVertex.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/RectangleVertex.kt
@@ -7,9 +7,6 @@ import java.nio.FloatBuffer
 class RectangleVertex {
     val vertexArray = createFloatBuffer(FULL_RECTANGLE_COORDS)
     val texCoordArray = createFloatBuffer(FULL_RECTANGLE_TEX_COORDS)
-    val vertexCount = FULL_RECTANGLE_COORDS.size / COORDS_PER_VERTEX
-    val vertexStride = COORDS_PER_VERTEX * SIZEOF_FLOAT
-    val texCoordStride = 2 * SIZEOF_FLOAT
 
     private fun createFloatBuffer(coords: FloatArray): FloatBuffer {
         val bb = ByteBuffer.allocateDirect(coords.size * 4)
@@ -21,8 +18,6 @@ class RectangleVertex {
     }
 
     companion object {
-        const val COORDS_PER_VERTEX = 2
-        private const val SIZEOF_FLOAT = 4
         private val FULL_RECTANGLE_COORDS = floatArrayOf(-1f, -1f, 1f, -1f, -1f, 1f, 1f, 1f)
         private val FULL_RECTANGLE_TEX_COORDS = floatArrayOf(0f, 0f, 1f, 0f, 0f, 1f, 1f, 1f)
     }

--- a/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
+++ b/app/src/main/java/com/kotlinisgood/boomerang/ui/videodoodle/VideoDoodleFragment.kt
@@ -239,7 +239,7 @@ class VideoDoodleFragment : Fragment(), SurfaceHolder.Callback,
         }
 
         if (!videoDoodleViewModel.isEncoderWorking) {
-            videoDoodleViewModel.encoder = Encoder(width, height, 6000000, 30, outputVideo)
+            videoDoodleViewModel.encoder = Encoder(width, height, outputVideo)
             encoderSurface = WindowSurface(egl, videoDoodleViewModel.encoder.inputSurface)
         }
         videoDoodleViewModel.isEncoderWorking = true


### PR DESCRIPTION
# Overview

## 렌더링 동작 과정 개선

### 버퍼 생성 과정 수정
- OpenGL ES의 Vertex Shader에 입력으로 들어가는 Vertex Array의 값을 Client-side에서 생성한 버퍼 대신 glGenBuffers(...)로 생성한 버퍼에 값을 넣어 전달하도록 수정

### 버퍼 최적화
- 버퍼로 들어가는 Vertex Array의 값은 고정되어 있음
- 따라서 버퍼의 usage를 `GLES20.GL_STATIC_DRAW`로 설정하여 최적화

## 인코더 수정
- 인코더의 I-Frame Interval을 1->5 로 수정하여 출력 동영상 용량 감소
- Encoder의 Bitrate, Framerate 파라미터를 제거하고 Encoder 클래스 내에서 가지고 있도록 수정
